### PR TITLE
Update win32 to support current version (v5)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,0 @@
-include: package:flutter_lints/flutter.yaml
-
-linter:
-  rules:
-    public_member_api_docs: true
-    # Ignoring unsafe_html as we need to import a JS script in wakelock_web and because of https://github.com/dart-lang/sdk/issues/45230.
-    unsafe_html: false

--- a/wakelock/analysis_options.yaml
+++ b/wakelock/analysis_options.yaml
@@ -1,11 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  exclude:
-    - 'lib/messages.dart'
-    - 'test/messages.dart'
-
 linter:
   rules:
     public_member_api_docs: true
-

--- a/wakelock/example/lib/main.dart
+++ b/wakelock/example/lib/main.dart
@@ -11,10 +11,10 @@ void main() {
 /// callback functions and a [FutureBuilder].
 class WakelockExampleApp extends StatefulWidget {
   /// Creates the [WakelockExampleApp] widget.
-  const WakelockExampleApp({Key key}) : super(key: key);
+  const WakelockExampleApp({Key? key}) : super(key: key);
 
   @override
-  _WakelockExampleAppState createState() => _WakelockExampleAppState();
+  State<WakelockExampleApp> createState() => _WakelockExampleAppState();
 }
 
 class _WakelockExampleAppState extends State<WakelockExampleApp> {

--- a/wakelock/example/pubspec.yaml
+++ b/wakelock/example/pubspec.yaml
@@ -3,13 +3,10 @@ description: >-2
   Example app demonstrating how to use the wakelock plugin. It also includes integration tests for
   testing the plugin in an integrated example.
 publish_to: 'none'
-version: 1.0.0+1
+version: 1.0.0+2
 
 environment:
-  # Opt out of null safety on purpose because dependencies do not support sound null safety yet
-  # and flutter drive ignores the --no-sound-null-safety parameter.
-  # todo(creativecreatorormaybenot): switch to 2.12.0-0 lower bound.
-  sdk: '>=2.11.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -31,7 +28,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 dependency_overrides:
   # We override the platform dependencies of wakelock here because we use the example app for

--- a/wakelock/example/windows/flutter/generated_plugins.cmake
+++ b/wakelock/example/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,9 @@
 list(APPEND FLUTTER_PLUGIN_LIST
 )
 
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
 set(PLUGIN_BUNDLED_LIBRARIES)
 
 foreach(plugin ${FLUTTER_PLUGIN_LIST})
@@ -13,3 +16,8 @@ foreach(plugin ${FLUTTER_PLUGIN_LIST})
   list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
   list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
 endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/wakelock/pubspec.yaml
+++ b/wakelock/pubspec.yaml
@@ -18,13 +18,13 @@ dependencies:
   wakelock_macos: ^0.4.0
   wakelock_platform_interface: ^0.3.0
   wakelock_web: ^0.4.0
-  wakelock_windows: ^0.2.0
+  wakelock_windows: ^0.2.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   pigeon: ^1.0.2 # flutter pub run pigeon --input "pigeons/messages.dart"
 
 flutter:

--- a/wakelock_macos/pubspec.yaml
+++ b/wakelock_macos/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 flutter:
   plugin:

--- a/wakelock_platform_interface/pubspec.yaml
+++ b/wakelock_platform_interface/pubspec.yaml
@@ -19,4 +19,4 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/wakelock_web/test/wakelock_web_test.dart
+++ b/wakelock_web/test/wakelock_web_test.dart
@@ -1,9 +1,11 @@
+@TestOn('browser')
+library wakelock_web_test;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wakelock/wakelock.dart';
 import 'package:wakelock_platform_interface/wakelock_platform_interface.dart';
 import 'package:wakelock_web/wakelock_web.dart';
 
-@TestOn('browser')
 void main() {
   group('$WakelockWeb', () {
     setUpAll(() async {

--- a/wakelock_windows/CHANGELOG.md
+++ b/wakelock_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+* Bumped the `win32` dependency to support v4 or v5.
+
 ## 0.2.1
 
 * Bumped the `win32` dependency from `^2.0.0` to `^3.0.0`.

--- a/wakelock_windows/lib/wakelock_windows.dart
+++ b/wakelock_windows/lib/wakelock_windows.dart
@@ -3,20 +3,6 @@ import 'dart:async';
 import 'package:wakelock_platform_interface/wakelock_platform_interface.dart';
 import 'package:win32/win32.dart';
 
-/// Informs the system that the state being set should remain in effect until
-/// the next call that uses ES_CONTINUOUS and one of the other state flags is
-/// cleared.
-///
-/// See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate#parameters.
-// ignore: constant_identifier_names
-const _ES_CONTINUOUS = 0x80000000;
-
-/// Forces the display to be on by resetting the display idle timer.
-///
-/// See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate#parameters.
-// ignore: constant_identifier_names
-const _ES_DISPLAY_REQUIRED = 0x00000002;
-
 /// The Windows implementation of the [WakelockPlatformInterface].
 ///
 /// This class implements the `wakelock` plugin functionality for Windows using
@@ -28,9 +14,9 @@ class WakelockWindows extends WakelockPlatformInterface {
   Future<void> toggle({required bool enable}) async {
     final int response;
     if (enable) {
-      response = SetThreadExecutionState(_ES_CONTINUOUS | _ES_DISPLAY_REQUIRED);
+      response = SetThreadExecutionState(ES_CONTINUOUS | ES_DISPLAY_REQUIRED);
     } else {
-      response = SetThreadExecutionState(_ES_CONTINUOUS);
+      response = SetThreadExecutionState(ES_CONTINUOUS);
     }
 
     // SetThreadExecutionState returns 0 if the operation failed.

--- a/wakelock_windows/pubspec.yaml
+++ b/wakelock_windows/pubspec.yaml
@@ -1,25 +1,25 @@
 name: wakelock_windows
 description: >-2
   Windows platform implementation of the wakelock_platform_interface for the wakelock plugin.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/creativecreatorormaybenot/wakelock/tree/main/wakelock_windows
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: '>=2.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
   wakelock_platform_interface: ^0.3.0
-  win32: ^3.0.0
+  # win32 is compatible across v4 and v5 for Win32 only (not COM)
+  win32: ">=4.0.0 <6.0.0"
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 # todo: use dartPluginClass declaration once that lands on stable (https://github.com/flutter/flutter/issues/52267_
 #flutter:


### PR DESCRIPTION
## Description

Updates win32 to support v5 (or v4, which is source compatible so long as you're not accessing COM APIs, which this code doesn't).

Copied from https://github.com/creativecreatorormaybenot/wakelock/pull/203
