### PR TITLE
Upgraded `package_info_plus` to 4.0.2

### DIFF
--- a/wakelock_linux/pubspec.yaml
+++ b/wakelock_linux/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.8.0
-  package_info_plus: ^3.0.2
+  package_info_plus: ^4.0.2
   wakelock_platform_interface: ^0.3.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Upgraded `package_info_plus` to 4.0.2.

Not sure if this should be treated as a breaking change for Android, as `package_info_plus` now requires AGP >= 4.2.