### PR TITLE
Fully defines function prototype to avoid xcode build warning

### DIFF
--- a/wakelock/ios/Classes/messages.m
+++ b/wakelock/ios/Classes/messages.m
@@ -108,7 +108,7 @@ static NSDictionary<NSString *, id> *wrapResult(id result, FlutterError *error) 
 }
 @end
 
-NSObject<FlutterMessageCodec> *FLTWakelockApiGetCodec() {
+NSObject<FlutterMessageCodec> *FLTWakelockApiGetCodec(void) {
   static dispatch_once_t s_pred = 0;
   static FlutterStandardMessageCodec *s_sharedObject = nil;
   dispatch_once(&s_pred, ^{


### PR DESCRIPTION
## Description

Adds void in a function's prototype to avoid xcode build warning
"A function declaration without a prototype is deprecated in all versions of C"
